### PR TITLE
Add openfaas-function-authorization to integration index

### DIFF
--- a/docs/website/scripts/integration-index/integrations.yaml
+++ b/docs/website/scripts/integration-index/integrations.yaml
@@ -106,6 +106,21 @@ integrations:
     inventors: 
     - google
 
+  openfaas-function-authorization:
+    title: OpenFaaS Serverless Function Authorization
+    description: OpenFaaS is a serverless function framework that runs on Docker Swarm and Kubernetes. OPA makes it possible to provide fine-grained context-aware authorization on a per-function basis.
+    labels:
+      layer: application
+      category: serverless
+    software:
+    - openfaas
+    code:
+    - https://github.com/adaptant-labs/openfaas-function-auth-opa
+    tutorials:
+    - https://github.com/adaptant-labs/openfaas-function-auth-opa/blob/master/README.md
+    inventors:
+    - adaptant
+
   kong-authorization:
     title: API Gateway Authorization with Kong
     description: Kong is a microservice API Gateway.  OPA provides fine-grained, context-aware control over the requests that Kong receives.
@@ -492,6 +507,9 @@ software:
   cloudflare:
     name: Cloudflare
     link: https://www.cloudflare.com
+  openfaas:
+    name: OpenFaaS
+    link: https://www.openfaas.com/
   minio:
     name: Minio
     link: https://min.io/


### PR DESCRIPTION
We have now also gotten OPA working with function-level authentication in OpenFaaS,
add this to the integration index.

Signed-off-by: Paul Mundt <paul.mundt@adaptant.io>